### PR TITLE
Issue 532: 	SMPPGateway - TON & NPI - code bug

### DIFF
--- a/src/java/org/smslib/smsserver/gateways/SMPPGateway.java
+++ b/src/java/org/smslib/smsserver/gateways/SMPPGateway.java
@@ -64,7 +64,7 @@ public class SMPPGateway extends AGateway
 		TypeOfNumber typeOfNumber=(ton==null)?TypeOfNumber.UNKNOWN:TypeOfNumber.valueOf(Byte.parseByte(ton));
 		
 		String npi=getProperty("sourcenpi");
-		NumberingPlanIndicator numberingPlanIndicator=(npi==null)?NumberingPlanIndicator.UNKNOWN:NumberingPlanIndicator.valueOf(Byte.parseByte(ton));
+		NumberingPlanIndicator numberingPlanIndicator=(npi==null)?NumberingPlanIndicator.UNKNOWN:NumberingPlanIndicator.valueOf(Byte.parseByte(npi));
 		
 		gateway.setSourceAddress(new Address(typeOfNumber, numberingPlanIndicator));
 		
@@ -72,7 +72,7 @@ public class SMPPGateway extends AGateway
 		typeOfNumber=(ton==null)?TypeOfNumber.UNKNOWN:TypeOfNumber.valueOf(Byte.parseByte(ton));
 		
 		npi=getProperty("destnpi");
-		numberingPlanIndicator=(npi==null)?NumberingPlanIndicator.UNKNOWN:NumberingPlanIndicator.valueOf(Byte.parseByte(ton));
+		numberingPlanIndicator=(npi==null)?NumberingPlanIndicator.UNKNOWN:NumberingPlanIndicator.valueOf(Byte.parseByte(npi));
 		
 		
 		gateway.setDestinationAddress(new Address(typeOfNumber, numberingPlanIndicator));
@@ -91,7 +91,7 @@ public class SMPPGateway extends AGateway
 		TypeOfNumber typeOfNumber=(ton==null)?TypeOfNumber.UNKNOWN:TypeOfNumber.valueOf(Byte.parseByte(ton));
 		
 		String npi=getProperty("bindnpi");
-		NumberingPlanIndicator numberingPlanIndicator=(npi==null)?NumberingPlanIndicator.UNKNOWN:NumberingPlanIndicator.valueOf(Byte.parseByte(ton));
+		NumberingPlanIndicator numberingPlanIndicator=(npi==null)?NumberingPlanIndicator.UNKNOWN:NumberingPlanIndicator.valueOf(Byte.parseByte(npi));
 		
 		return new BindAttributes(systemId, password, systemType, bindType, new Address(typeOfNumber, numberingPlanIndicator));
 	}


### PR DESCRIPTION
https://code.google.com/p/smslib/issues/detail?id=532&sort=-id&colspec=ID%20Type%20Status%20Component%20Milestone%20Priority%20Stars%20Owner%20Summary

Hi there just found a bug in the SMPPGateway - org.smslib.smsserver.gateways

create() and getBindAttributes()

The NPI where using the TON values, causing problems when the number doesnt exists in the NPI values. (EX: TON = 5, causes gateway error)

It's a classic Copy/Paste error.

Fix change in 3 places:

NumberingPlanIndicator numberingPlanIndicator=(npi==null)?NumberingPlanIndicator.UNKNOWN:NumberingPlanIndicator.valueOf(Byte.parseByte(ton));

to:

NumberingPlanIndicator numberingPlanIndicator=(npi==null)?NumberingPlanIndicator.UNKNOWN:NumberingPlanIndicator.valueOf(Byte.parseByte(npi));
