### PR TITLE
Add Huawei E220 AT Handler

### DIFF
--- a/src/java/org/smslib/modem/athandler/ATHandler_Huawei_E220.java
+++ b/src/java/org/smslib/modem/athandler/ATHandler_Huawei_E220.java
@@ -1,0 +1,47 @@
+// SMSLib for Java v3
+// A Java API library for sending and receiving SMS via a GSM modem
+// or other supported gateways.
+// Web Site: http://www.smslib.org
+//
+// Copyright (C) 2002-2012, Thanasis Delenikas, Athens/GREECE.
+// SMSLib is distributed under the terms of the Apache License version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.smslib.modem.athandler;
+
+import java.io.IOException;
+import org.smslib.GatewayException;
+import org.smslib.TimeoutException;
+import org.smslib.modem.ModemGateway;
+
+/**
+ * AT Handler for Huawei E220 modems.
+ */
+
+public class ATHandler_Huawei_E220 extends ATHandler_Huawei {
+
+	public ATHandler_Huawei_E220(ModemGateway myGateway) {
+		super(myGateway);
+	}
+
+	@Override
+	public void init() throws TimeoutException, GatewayException, IOException, InterruptedException
+	{
+		super.init();
+		getModemDriver().write("AT+CSCA?\r");
+		String smsc = getModemDriver().getResponse();
+		getModemDriver().write("AT+CSCA=" + smsc + "\r");
+		getModemDriver().getResponse();
+	}
+}


### PR DESCRIPTION
This is based off information from [this blog post](http://myraspberryandme.wordpress.com/2013/09/13/short-message-texting-sms-with-huawei-e220/), at the very end.  This modem apparently has a quirk which makes it return error 330 (i.e. unknnown SMSC) unless `AT+CSCA` is called at least once.  This patch just does what the blog post suggests, which is to feed the value of `AT+CSCA?` back into it.
